### PR TITLE
把stars的颜色改成黄色

### DIFF
--- a/src/components/mcg-layout/header.vue
+++ b/src/components/mcg-layout/header.vue
@@ -6,7 +6,7 @@
       <a href="https://github.com/tuanzisama/minecraft-color-gradient-generator" target="_blank"
         rel="noopener noreferrer nofollow">
         <img alt="GitHub Repo stars"
-          src="https://img.shields.io/github/stars/tuanzisama/minecraft-color-gradient-generator?style=flat-square&labelColor=%23f5f7fa&color=%23909399">
+          src="https://img.shields.io/github/stars/tuanzisama/minecraft-color-gradient-generator?style=flat-square&labelColor=%23f5f7fa&color=ffe156">
       </a>
     </p>
   </header>


### PR DESCRIPTION
不知道是不是您故意这样设计的，但我认为把stars信息设为黄色更加符合认知直觉
Before:
![image](https://github.com/tuanzisama/minecraft-color-gradient-generator/assets/97295993/03d7e9a8-dd77-44fd-ac04-bc18f0f03f06)
After:
![image](https://github.com/tuanzisama/minecraft-color-gradient-generator/assets/97295993/4918ad53-86d2-4944-bdbc-6f8b4f5f55cd)
如果这是您为了统一风格设计的请无视此PR QAQ